### PR TITLE
Fix typo in czech declariation and add AI declaration for english

### DIFF
--- a/template/front.typ
+++ b/template/front.typ
@@ -8,7 +8,7 @@
     "specialization": "Specializace",
     "acknowledgement": "Poděkování",
     "declaration": "Prohlášení",
-    "declaration-text": "Prohlašuji, že jsem závěrečnou práci vypracoval(a) samostatně a uvedl(a) všekeré použité informační zdroje v souladu s Metodickým pokynem o dodržování etických principů při přípravě vysokoškolských závěrečných prací a Rámcovými pravidly používání umělé inteligence na ČVUT pro studijní a pedagogické účely v Bc a NM studiu.",
+    "declaration-text": "Prohlašuji, že jsem závěrečnou práci vypracoval(a) samostatně a uvedl(a) veškeré použité informační zdroje v souladu s Metodickým pokynem o dodržování etických principů při přípravě vysokoškolských závěrečných prací a Rámcovými pravidly používání umělé inteligence na ČVUT pro studijní a pedagogické účely v Bc a Mgr studiu.",
     "ai-declaration-text": "Prohlašuji, že jsem v průběhu příprav a psaní závěrečné práce použil nástroje umělé inteligence. Vygenerovaný obsah jsem ověřil. Stvrzuji, že jsem si vědom, že za obsah závěrečné práce plně zodpovídám.",
     "prague": "v Praze",
     "abstract": "Abstrakt",
@@ -28,8 +28,7 @@
     "acknowledgement": "Acknowledgement",
     "declaration": "Declaration",
     "declaration-text": "I declare that the presented work was developed independently and that I have listed all sources of information used within it in accordance with the methodical instructions for observing the ethical principles in the preparation of university theses.",
-    "ai-declaration-text": "Prohlašuji, že jsem v průběhu příprav a psaní závěrečné práce použil nástroje umělé inteligence.Vygenerovaný
-obsah jsem ověřil. Stvrzuji, že jsem si vědom, že za obsah závěrečné práce plně zodpovídám.",
+    "ai-declaration-text": "I declare that I have used AI tools during the preparation and writing of my thesis. I have verified the generated content. I confirm that I am aware that I am fully responsible for the content of the thesis.",
     "prague": "In Prague",
     "abstract": "Abstract",
     "abbrs": "List of Abbreviations",


### PR DESCRIPTION
- fix typos in czech `declaration-text`
- add English `ai-declaration-text` (copied from https://courses.fit.cvut.cz/SZZ/dokumenty/files/Prohlaseni_k_pouziti_AI_EN.pdf) 